### PR TITLE
Initialize backend with FastAPI, add /health and /chat routes

### DIFF
--- a/convo_backend/.gitignore
+++ b/convo_backend/.gitignore
@@ -1,0 +1,133 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies is a problem,
+#   one should ignore Pipfile.lock.
+# Pipfile.lock
+
+# PEP 582; __pypackages__
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/ 

--- a/convo_backend/README.md
+++ b/convo_backend/README.md
@@ -1,0 +1,31 @@
+# Convo 🤖
+
+**Convo** is an open-source, self-hostable chatbot platform built with Python. It enables easy deployment of conversational AI on any website without third-party dependencies.
+
+## 🚀 Features (Planned)
+
+- Self-hostable with Docker or manual setup
+- Embeddable chatbot widget for any website
+- Integration with OpenAI / local LLMs
+- Customizable prompts and personas
+- Admin panel for managing chats and analytics
+- Multi-language support
+
+## 🛠️ Tech Stack
+
+- Python (FastAPI or Flask)
+- SQLite or PostgreSQL
+- JavaScript (for widget frontend)
+- HTML/CSS
+
+## 📦 Installation
+
+_TBD_ – Soon to be documented.
+
+## 👥 Contributing
+
+Contributions are welcome! Please check the [Roadmap](docs/ROADMAP.md) and open issues to get started.
+
+## 📄 License
+
+MIT

--- a/convo_backend/main.py
+++ b/convo_backend/main.py
@@ -1,0 +1,27 @@
+# main.py
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+# Pydantic model for the request body of the /chat endpoint
+class ChatRequest(BaseModel):
+    message: str
+
+# GET endpoint for health checks
+@app.get("/health")
+async def health_check():
+    """
+    This endpoint can be used for health checks.
+    It returns a simple JSON response indicating the service is running.
+    """
+    return {"status": "OK"}
+
+# POST endpoint to handle chat messages
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    """
+    This endpoint receives a chat message and returns a dummy response.
+    It uses the ChatRequest model for request body validation.
+    """
+    return {"reply": f"This is a dummy response to your message: '{request.message}'"} 

--- a/convo_backend/requirements.txt
+++ b/convo_backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.111.0
+uvicorn==0.29.0
+pydantic==2.7.1 


### PR DESCRIPTION
Closes  #1 

- Adds a `GET /health` endpoint for service monitoring.
- Adds a `POST /chat` endpoint with a dummy response and Pydantic validation.
- Defines core dependencies in `requirements.txt` for project setup.
- Sets up initial FastAPI backend structure.
